### PR TITLE
Couple updates/ Additional checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,10 +18,3 @@ commit_email=""
 # removing /* from the end of the path may have undesired effects on your backup
 
 path_klipperdata=printer_data/config/*
-
-# Backup Location
-# The below path is the location you would like to create a backp folder in, by default the path begins at $HOME which is /home/{username}
-# At least one folder level eg.) backup_folder=config_backup is required to be defined here, and the path cannot be the root directory of /home/{username}/
-# You can have a longer path as well eg.) backup_folder=config_backup/printer_data/config could be used if you wanted the backup to match the path it was pulled from.
-
-backup_folder=config_backup/klipper

--- a/.env.example
+++ b/.env.example
@@ -6,15 +6,22 @@ commit_username=""
 commit_email=""
 
 # Indivdual file syntax:
-#  Note: script.sh starts its search in $HOME which is /home/{username}/ 
+#  Note: script.sh starts its search in $HOME which is /home/{username}/
 # Using below example the script will search for: /home/{username}/printer_data/config/printer.cfg
 
 #path_printercfg=printer_data/config/printer.cfg
 
 # Backup folder syntax:
-#  Note: script.sh starts its search in $HOME which is /home/{username}/ 
+#  Note: script.sh starts its search in $HOME which is /home/{username}/
 # Using below example the script will search for: /home/{username}/printer_data/config/*
-# The star denotes a wildcard meaning that any and all files in the folder will be selected
+# /* must always be at the end of the path when backing up a folder so that the files inside of the folder are properly filtered and searched
+# removing /* from the end of the path may have undesired effects on your backup
+
 path_klipperdata=printer_data/config/*
+
+# Backup Location
+# The below path is the location you would like to create a backp folder in, by default the path begins at $HOME which is /home/{username}
+# At least one folder level eg.) backup_folder=config_backup is required to be defined here, and the path cannot be the root directory of /home/{username}/
+# You can have a longer path as well eg.) backup_folder=config_backup/printer_data/config could be used if you wanted the backup to match the path it was pulled from.
 
 backup_folder=config_backup/klipper

--- a/script.sh
+++ b/script.sh
@@ -30,9 +30,10 @@ fi
 
 while IFS= read -r path; do
   # Check that the path is not a file (so it must be some sort of directory) and check if it ends in /* and add if it does not exist
-  if [[ ! "$path" =~ \*$ && ! "$path" =~ /$ && ! -f "$path" ]]; then
+  # Also checking if file ends in any file extension (.txt,.cfg, etc...) as linux test with -f reports that .cfg is not a file
+  if [[ ! "$path" =~ \*$ && ! "$path" =~ /$ && ! -f "$path" && ! "$path" =~ \.[^.]+$ ]]; then
     path="$path/*"
-  elif [[ ! "$path" =~ \$ && ! -f "$path" ]]; then
+  elif [[ ! "$path" =~ \$ && ! -f "$path" && ! "$path" =~ \.[^.]+$ ]]; then
     path="$path*"
   fi
   # Iterate over every file in the path

--- a/script.sh
+++ b/script.sh
@@ -65,6 +65,6 @@ fi
 [[ "$commit_email" != "" ]] && git config user.email "$commit_email" || git config user.email "$(whoami)@$(hostname --long)"
 git add .
 git commit -m "$commit_message"
-git push -u https://"$github_token"@github.com/"$github_username"/"$github_repository".git $branch
+git push -f -u https://"$github_token"@github.com/"$github_username"/"$github_repository".git $branch
 # Remove klipper folder after backup so that any file deletions can be logged on next backup
 rm -rf $HOME/$backup_folder/

--- a/script.sh
+++ b/script.sh
@@ -50,9 +50,9 @@ done < <(grep -v '^#' "$parent_path/.env" | grep 'path_' | sed 's/^.*=//')
 # Check if backup_folder path depth is greater than 1, this is needed to ensure that if path is only 1 level deep we do not create the git repo in /home/{username}/
 # we DO NOT want to use backup_path here as we want to exclude /home/{username}/ from the awk search
 if [[ $backup_folderDepth -gt 1 ]]; then
-backup_parent_directory=$(echo "$backup_folder" | awk -F'/' '{print $1}') # first level of backup path
+  backup_parent_directory=$(echo "$backup_folder" | awk -F'/' '{print $1}') # first level of backup path
 else
-backup_parent_directory=$backup_folder
+  backup_parent_directory=$backup_folder
 fi
 
 cp "$parent_path"/.gitignore "$HOME/$backup_parent_directory/.gitignore"

--- a/script.sh
+++ b/script.sh
@@ -13,7 +13,7 @@ source "$parent_path"/.env
 # Check that backup_folder is not set to root of users home directory
 backup_folderDepth=$(echo "$backup_folder" | tr '/' '\n' | grep -c .)
 if [[ $backup_folder == '.' ]]; then
-  echo "$(tput setaf 1)Your \$backup_folder path cannot be the root of: $HOME"
+  echo "$(tput setaf 1)Your backup_folder path cannot be the root of: $HOME"
   echo "Please change the path location in .env!$(tput sgr0)"
   exit
 fi

--- a/script.sh
+++ b/script.sh
@@ -29,9 +29,9 @@ if [ ! -d $backup_path ]; then
 fi
 
 while IFS= read -r path; do
-  # Check if path is a directory
-  if [[ -d "$HOME/$path" ]]; then
-  # Check if path does not end in /* includes a file extention and add
+  # Check if path is a directory or not a file (needed for /* checking as /* treats the path as not a directory)
+  if [[ -d "$HOME/$path" || ! -f "$HOME/$path" ]]; then
+  # Check if path does not end in /* or /
     if [[ ! "$path" =~ /\*$ && ! "$path" =~ /$ ]]; then
       path="$path/*"
     elif [[ ! "$path" =~ \$ && ! "$path" =~ /\*$ ]]; then

--- a/script.sh
+++ b/script.sh
@@ -29,12 +29,14 @@ if [ ! -d $backup_path ]; then
 fi
 
 while IFS= read -r path; do
-  # Check that the path is not a file (so it must be some sort of directory) and check if it ends in /* and add if it does not exist
-  # Also checking if file ends in any file extension (.txt,.cfg, etc...) as linux test with -f reports that .cfg is not a file
-  if [[ ! "$path" =~ \*$ && ! "$path" =~ /$ && ! -f "$path" && ! "$path" =~ \.[^.]+$ ]]; then
-    path="$path/*"
-  elif [[ ! "$path" =~ \$ && ! -f "$path" && ! "$path" =~ \.[^.]+$ ]]; then
-    path="$path*"
+  # Check if path is a directory
+  if [[ -d "$HOME/$path" ]]; then
+  # Check if path does not end in /* includes a file extention and add
+    if [[ ! "$path" =~ /\*$ && ! "$path" =~ /$ ]]; then
+      path="$path/*"
+    elif [[ ! "$path" =~ \$ && ! "$path" =~ /\*$ ]]; then
+      path="$path*"
+    fi
   fi
   # Iterate over every file in the path
   for file in $HOME/$path; do

--- a/script.sh
+++ b/script.sh
@@ -10,12 +10,22 @@ parent_path=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd -P)
 # Initialize variables from .env file
 source "$parent_path"/.env
 
+# Check that backup_folder is not set to root of users home directory
+backup_folderDepth=$(echo "$backup_folder" | tr '/' '\n' | grep -c .)
+if [[ $backup_folder == '.' ]]; then
+echo "Your \$backup_folder path cannot be the root of: $HOME"
+echo "Please change the path location in .env!"
+exit 1
+fi
+
 # Change directory to parent path
 cd "$parent_path" || exit
 
+backup_path="$HOME/$backup_folder"
+
 # Check if backup folder exists, create one if it does not
-if [ ! -d "$HOME/$backup_folder" ]; then
-  mkdir -p "$HOME/$backup_folder"
+if [ ! -d $backup_path ]; then
+  mkdir -p $backup_path
 fi
 
 while IFS= read -r path; do
@@ -28,14 +38,22 @@ while IFS= read -r path; do
     elif [[ $(basename "$file") =~ ^printer-[0-9]+_[0-9]+\.cfg$ ]]; then
         echo "Skipping file: $file"
     else
-      cp -r $file $HOME/$backup_folder/
+      cp -r $file $backup_path/
     fi
   done
 done < <(grep -v '^#' "$parent_path/.env" | grep 'path_' | sed 's/^.*=//')
 
-# Add basic readme to backup repo
-backup_parent_directory=$(dirname "$backup_folder")
+# Check if backup_folder path depth is greater than 1, this is needed to ensure that if path is only 1 level deep we do not create the git repo in /home/{username}/
+# we DO NOT want to use backup_path here as we want to exclude /home/{username}/ from the awk search
+if [[ $backup_folderDepth -gt 1 ]]; then
+backup_parent_directory=$(echo "$backup_folder" | awk -F'/' '{print $1}') # first level of backup path
+else
+backup_parent_directory=$backup_folder
+fi
+
 cp "$parent_path"/.gitignore "$HOME/$backup_parent_directory/.gitignore"
+
+# Create and add Readme to backup folder
 echo -e "# klipper-backup 💾 \nKlipper backup script for manual or automated GitHub backups \n\nThis backup is provided by [klipper-backup](https://github.com/Staubgeborener/klipper-backup)." > "$HOME/$backup_parent_directory/README.md"
 
 # Individual commit message, if no parameter is set, use the current timestamp as commit message
@@ -52,7 +70,7 @@ fi
 cd "$HOME/$backup_parent_directory"
 # Check if .git exists else init git repo
 if [ ! -d ".git" ]; then
-  mkdir .git 
+  mkdir .git
   echo "[init]
           defaultBranch = $branch_name" >> .git/config #Add desired branch name to config before init
   git init
@@ -66,5 +84,11 @@ fi
 git add .
 git commit -m "$commit_message"
 git push -f -u https://"$github_token"@github.com/"$github_username"/"$github_repository".git $branch
-# Remove klipper folder after backup so that any file deletions can be logged on next backup
-rm -rf $HOME/$backup_folder/
+
+# Remove backup folder after backup so that any file deletions can be logged on next backup
+if [[ $backup_folderDepth -gt 1 ]]; then
+  rm -rf $backup_path
+  find $HOME/$backup_parent_directory -type d -empty -delete
+elif [ -d $backup_path ]; then
+    find $backup_path -maxdepth 1 -mindepth 1 ! -name '.git' -exec rm -rf {} \;
+fi


### PR DESCRIPTION
- Added a check for if backup_folder=. and exit while informing the user that the backup folder cannot be the root directory of /home/{username}/
- created a backup_path variable within script.sh as there were 5 plus areas where the same $HOME/$backup_folder was being used so having a variable that you only need to change once to change all of them seems better
- added some additional checks for proper file and folder removal after the backup is pushed
- improved git commands so that if adding an existing backup repository or deleting the backup folder entirely the repo can be properly reinitialized and pulled.
- add check for when backing up and entire folder ensure that /* is in the path or else cp -r will not correctly check the individual files.
- few minor adjustments i might be forgetting about but either was formatting, ensuring variables are enclosed in brackets , or that $backup_path is now used where $HOME/backup_folder was previously placed