### PR TITLE
addition of excludes variable and other changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,18 @@ branch_name=main
 commit_username=""
 commit_email=""
 
+# Array of strings in .gitignore pattern format https://git-scm.com/docs/gitignore#_pattern_format for files that should not be uploaded to the remote repo
+# New additions must be enclosed in double quotes and should follow the pattern format as noted in the above link
+exclude=( \
+"*.swp" \
+"*.tmp" \
+"printer-[0-9]*_[0-9]*.cfg" \
+"*.bak" \
+"*.bkp" \
+"*.csv" \
+"*.zip" \
+)
+
 # Indivdual file syntax:
 #  Note: script.sh starts its search in $HOME which is /home/{username}/
 # Using below example the script will search for: /home/{username}/printer_data/config/printer.cfg

--- a/script.sh
+++ b/script.sh
@@ -10,10 +10,10 @@ backup_folder="config_backup"
 backup_path="$HOME/$backup_folder"
 git_host=${git_host:-"github.com"}
 full_git_url="https://"$github_token"@"$git_host"/"$github_username"/"$github_repository".git"
+exclude=${exclude:-"*.swp" "*.tmp" "printer-[0-9]*_[0-9]*.cfg" "*.bak" "*.bkp" "*.csv" "*.zip"}
 
 # Check for updates
-[ $(git -C "$parent_path" rev-parse HEAD) = $(git -C "$parent_path" ls-remote $(git -C "$parent_path" rev-parse --abbrev-ref @{u} | \
-sed 's/\// /g') | cut -f1) ] && echo -e "Klipper-backup is up to date\n" || echo -e "NEW klipper-backup version available!\n"
+[ $(git -C "$parent_path" rev-parse HEAD) = $(git -C "$parent_path" ls-remote $(git -C "$parent_path" rev-parse --abbrev-ref @{u} | sed 's/\// /g') | cut -f1) ] && echo -e "Klipper-backup is up to date\n" || echo -e "NEW klipper-backup version available!\n"
 
 # Check if backup folder exists, create one if it does not
 if [ ! -d "$backup_path" ]; then
@@ -68,8 +68,6 @@ if [[ "$full_git_url" != $(git remote get-url origin) ]]; then
     git remote set-url origin "$full_git_url"
 fi
 
-git config advice.skippedCherryPicks false
-
 # Check if branch exists on remote (newly created repos will not yet have a remote) and pull any new changes
 if git ls-remote --exit-code --heads origin $branch_name > /dev/null 2>&1; then
     git pull origin "$branch_name"
@@ -93,12 +91,9 @@ while IFS= read -r path; do
     if compgen -G "$HOME/$path" > /dev/null; then
         # Iterate over every file in the path
         for file in $path; do
-            # Check if it's a symbolic link
+            # Skip if file is symbolic link
             if [ -h "$file" ]; then
                 echo "Skipping symbolic link: $file"
-                # Check if file is an extra backup of printer.cfg moonraker/klipper seems to like to make 4-5 of these sometimes no need to back them all up as well.
-                elif [[ $(basename "$file") =~ ^printer-[0-9]+_[0-9]+\.cfg$ ]]; then
-                echo "Skipping file: $file"
             else
                 cp -r --parents "$file" "$backup_path/"
             fi
@@ -107,6 +102,13 @@ while IFS= read -r path; do
 done < <(grep -v '^#' "$parent_path/.env" | grep 'path_' | sed 's/^.*=//')
 
 cp "$parent_path"/.gitignore "$backup_path/.gitignore"
+
+# Loop through exclude array and add each element to the end of .gitignore so that git does not upload them to remote
+for i in ${exclude[@]}; do
+    # add new line to end of .gitignore if there is not one
+    [[ $(tail -c1 "$backup_path/.gitignore" | wc -l) -eq 0 ]] && echo "" >> "$backup_path/.gitignore"
+    echo $i >> "$backup_path/.gitignore"
+done
 
 # Create and add Readme to backup folder
 echo -e "# klipper-backup 💾 \nKlipper backup script for manual or automated GitHub backups \n\nThis backup is provided by [klipper-backup](https://github.com/Staubgeborener/klipper-backup)." > "$backup_path/README.md"
@@ -119,6 +121,8 @@ else
 fi
 
 cd "$backup_path"
+# Untrack all files so that any new excluded files are correctly ignored and deleted from remote
+git rm -r --cached . > /dev/null 2>&1
 git add .
 git commit -m "$commit_message"
 # Check if HEAD still matches remote (Means there are no updates to push) and create a empty commit just informing that there are no new updates to push


### PR DESCRIPTION
remove `git config advice.skippedCherryPicks false` from script.sh as it is no longer needed as there are no merge or rebases occuring that would require cherrypicks. 

Created new variable exclude which is an array of strings using .gititgnore pattern format https://git-scm.com/docs/gitignore#_pattern_format to create a list of files or folders that should not be uploaded to the remote and places that list into .gitignore before the backup is pushed.

Change line 16 & 17 to be a single line on 16