### PR TITLE
Add exlude list, preserve README.md, allow multiple branches per repo, lint and pretty code.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,15 @@ commit_email=""
 # `/*` should always be at the end of the path when backing up a folder so that the files inside of the folder are properly filtered and searched
 
 path_klipperdata=printer_data/config/*
+
+# Array of strings in .gitignore pattern git format https://git-scm.com/docs/gitignore#_pattern_format for files that should not be uploaded to the remote repo
+# New additions must be enclosed in double quotes and should follow the pattern format as noted in the above link
+exclude=( \
+"*.swp" \
+"*.tmp" \
+"printer-[0-9]*_[0-9]*.cfg" \
+"*.bak" \
+"*.bkp" \
+"*.csv" \
+"*.zip" \
+)

--- a/script.sh
+++ b/script.sh
@@ -34,7 +34,7 @@ if [ ! -d ".git" ]; then
     git init
 # Check if the current checked out branch matches the branch name given in .env if not branch listed in .env
 elif [[ $(git symbolic-ref --short -q HEAD) != "$branch_name" ]]; then
-    echo -e "Branch: $branch_name in .env does not match the currently checked out branch of: $(git symbolic-ref --short -q HEAD).\nSwitching to branch: $branch_name"
+    echo -e "Branch: $branch_name in .env does not match the currently checked out branch of: $(git symbolic-ref --short -q HEAD)."
     # Create branch if it does not exist
     if git show-ref --quiet refs/heads/"$branch"; then
         git checkout "$branch_name"

--- a/script.sh
+++ b/script.sh
@@ -34,7 +34,7 @@ if [ ! -d ".git" ]; then
     git init
 # Check if the current checked out branch matches the branch name given in .env if not branch listed in .env
 elif [[ $(git symbolic-ref --short -q HEAD) != "$branch_name" ]]; then
-    echo "Branch: $branch_name in .env does not match the currently checked out branch: $(git symbolic-ref --short -q HEAD) switching to branch: $branch_name"
+    echo -e "Branch: $branch_name in .env does not match the currently checked out branch of: $(git symbolic-ref --short -q HEAD).\nSwitching to branch: $branch_name"
     # Create branch if it does not exist
     if git show-ref --quiet refs/heads/"$branch"; then
         git checkout "$branch_name"

--- a/script.sh
+++ b/script.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
 # Set parent directory path
-parent_path=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd -P)
+parent_path=$(
+    cd "$(dirname "${BASH_SOURCE[0]}")"
+    pwd -P
+)
 
 # Initialize variables from .env file
 source "$parent_path"/.env
@@ -13,8 +16,8 @@ git_host=${git_host:-"github.com"}
 full_git_url="https://"$github_token"@"$git_host"/"$github_username"/"$github_repository".git"
 
 # Check for updates
-[ $(git -C "$parent_path" rev-parse HEAD) = $(git -C "$parent_path" ls-remote $(git -C "$parent_path" rev-parse --abbrev-ref @{u} | \
-sed 's/\// /g') | cut -f1) ] && echo -e "Klipper-backup is up to date\n" || echo -e "NEW klipper-backup version available!\n"
+[ $(git -C "$parent_path" rev-parse HEAD) = $(git -C "$parent_path" ls-remote $(git -C "$parent_path" rev-parse --abbrev-ref @{u} |
+    sed 's/\// /g') | cut -f1) ] && echo -e "Klipper-backup is up to date\n" || echo -e "NEW klipper-backup version available!\n"
 
 # Check if backup folder exists, create one if it does not
 if [ ! -d "$backup_path" ]; then
@@ -27,10 +30,10 @@ cd "$backup_path"
 if [ ! -d ".git" ]; then
     mkdir .git
     echo "[init]
-    defaultBranch = "$branch_name"" >> .git/config #Add desired branch name to config before init
+    defaultBranch = "$branch_name"" >>.git/config #Add desired branch name to config before init
     git init
-    # Check if the current checked out branch matches the branch name given in .env if not update to new branch
-    elif [[ $(git symbolic-ref --short -q HEAD) != "$branch_name" ]]; then
+# Check if the current checked out branch matches the branch name given in .env if not update to new branch
+elif [[ $(git symbolic-ref --short -q HEAD) != "$branch_name" ]]; then
     echo "New branch in .env detected, rename $(git symbolic-ref --short -q HEAD) to $branch_name branch"
     git branch -m "$branch_name"
 fi
@@ -48,7 +51,7 @@ if [[ "$commit_email" != "" ]]; then
     git config user.email "$commit_email"
 else
     # Get the MAC address of the first network interface for unique id
-    if ! command -v ifconfig &> /dev/null; then
+    if ! command -v ifconfig &>/dev/null; then
         mac_address=$(ipconfig | grep -o -E '([0-9a-fA-F]:?){6}' | head -n 1)
     else
         mac_address=$(ifconfig | grep -o -E '([0-9a-fA-F]:?){6}' | head -n 1)
@@ -72,7 +75,7 @@ fi
 git config advice.skippedCherryPicks false
 
 # Check if branch exists on remote (newly created repos will not yet have a remote) and pull any new changes
-if git ls-remote --exit-code --heads origin $branch_name > /dev/null 2>&1; then
+if git ls-remote --exit-code --heads origin $branch_name >/dev/null 2>&1; then
     git pull origin "$branch_name"
     # Delete the pulled files so that the directory is empty again before copying the new backup
     # The pull is only needed so that the repository nows its on latest and does not require rebases or merges
@@ -86,19 +89,19 @@ while IFS= read -r path; do
         # Check if path does not end in /* or /
         if [[ ! "$path" =~ /\*$ && ! "$path" =~ /$ ]]; then
             path="$path/*"
-            elif [[ ! "$path" =~ \$ && ! "$path" =~ /\*$ ]]; then
+        elif [[ ! "$path" =~ \$ && ! "$path" =~ /\*$ ]]; then
             path="$path*"
         fi
     fi
     # Check if path contains files
-    if compgen -G "$HOME/$path" > /dev/null; then
+    if compgen -G "$HOME/$path" >/dev/null; then
         # Iterate over every file in the path
         for file in $path; do
             # Check if it's a symbolic link
             if [ -h "$file" ]; then
                 echo "Skipping symbolic link: $file"
-                # Check if file is an extra backup of printer.cfg moonraker/klipper seems to like to make 4-5 of these sometimes no need to back them all up as well.
-                elif [[ $(basename "$file") =~ ^printer-[0-9]+_[0-9]+\.cfg$ ]]; then
+            # Check if file is an extra backup of printer.cfg moonraker/klipper seems to like to make 4-5 of these sometimes no need to back them all up as well.
+            elif [[ $(basename "$file") =~ ^printer-[0-9]+_[0-9]+\.cfg$ ]]; then
                 echo "Skipping file: $file"
             else
                 cp -r --parents "$file" "$backup_path/"
@@ -110,7 +113,7 @@ done < <(grep -v '^#' "$parent_path/.env" | grep 'path_' | sed 's/^.*=//')
 cp "$parent_path"/.gitignore "$backup_path/.gitignore"
 
 # Create and add Readme to backup folder
-echo -e "# klipper-backup 💾 \nKlipper backup script for manual or automated GitHub backups \n\nThis backup is provided by [klipper-backup](https://github.com/Staubgeborener/klipper-backup)." > "$backup_path/README.md"
+echo -e "# klipper-backup 💾 \nKlipper backup script for manual or automated GitHub backups \n\nThis backup is provided by [klipper-backup](https://github.com/Staubgeborener/klipper-backup)." >"$backup_path/README.md"
 
 # Individual commit message, if no parameter is set, use the current timestamp as commit message
 if [ -n "$1" ]; then

--- a/script.sh
+++ b/script.sh
@@ -80,7 +80,7 @@ if git ls-remote --exit-code --heads origin $branch_name >/dev/null 2>&1; then
     git pull origin "$branch_name"
     # Delete the pulled files so that the directory is empty again before copying the new backup
     # The pull is only needed so that the repository nows its on latest and does not require rebases or merges
-    find "$backup_path" -maxdepth 1 -mindepth 1 ! -name '.git' -exec rm -rf {} \;
+    find "$backup_path" -maxdepth 1 -mindepth 1 ! -name '.git' ! -name 'README.md' -exec rm -rf {} \;
 fi
 
 cd "$HOME"
@@ -120,9 +120,6 @@ for i in ${exclude[@]}; do
     echo $i >>"$backup_path/.gitignore"
 done
 
-# Create and add Readme to backup folder
-echo -e "# klipper-backup 💾 \nKlipper backup script for manual or automated GitHub backups \n\nThis backup is provided by [klipper-backup](https://github.com/Staubgeborener/klipper-backup)." >"$backup_path/README.md"
-
 # Individual commit message, if no parameter is set, use the current timestamp as commit message
 if [ -n "$1" ]; then
     commit_message="$@"
@@ -131,6 +128,10 @@ else
 fi
 
 cd "$backup_path"
+# Create and add Readme to backup folder if it doesn't already exist
+if ! [ -f "README.md" ]; then
+    echo -e "# klipper-backup 💾 \nKlipper backup script for manual or automated GitHub backups \n\nThis backup is provided by [klipper-backup](https://github.com/Staubgeborener/klipper-backup)." >"$backup_path/README.md"
+fi
 git add .
 git commit -m "$commit_message"
 # Check if HEAD still matches remote (Means there are no updates to push) and create a empty commit just informing that there are no new updates to push

--- a/script.sh
+++ b/script.sh
@@ -36,10 +36,10 @@ if [ ! -d ".git" ]; then
 elif [[ $(git symbolic-ref --short -q HEAD) != "$branch_name" ]]; then
     echo -e "Branch: $branch_name in .env does not match the currently checked out branch of: $(git symbolic-ref --short -q HEAD)."
     # Create branch if it does not exist
-    if git show-ref --quiet refs/heads/"$branch"; then
-        git checkout "$branch_name"
+    if git show-ref --quiet --verify "refs/heads/$branch_name"; then
+        git checkout "$branch_name" >/dev/null
     else
-        git checkout -b "$branch_name"
+        git checkout -b "$branch_name" >/dev/null
     fi
 fi
 

--- a/script.sh
+++ b/script.sh
@@ -129,6 +129,9 @@ cd "$backup_path"
 if ! [ -f "README.md" ]; then
     echo -e "# klipper-backup 💾 \nKlipper backup script for manual or automated GitHub backups \n\nThis backup is provided by [klipper-backup](https://github.com/Staubgeborener/klipper-backup)." >"$backup_path/README.md"
 fi
+
+# Untrack all files so that any new excluded files are correctly ignored and deleted from remote
+git rm -r --cached . >/dev/null 2>&1
 git add .
 git commit -m "$commit_message"
 # Check if HEAD still matches remote (Means there are no updates to push) and create a empty commit just informing that there are no new updates to push

--- a/script.sh
+++ b/script.sh
@@ -140,4 +140,4 @@ fi
 git push -u origin "$branch_name"
 
 # Remove files except .git folder after backup so that any file deletions can be logged on next backup
-find "$backup_path" -maxdepth 1 -mindepth 1 ! -name '.git' -exec rm -rf {} \;
+find "$backup_path" -maxdepth 1 -mindepth 1 ! -name '.git' ! -name 'README.md' -exec rm -rf {} \;

--- a/script.sh
+++ b/script.sh
@@ -72,8 +72,6 @@ if [[ "$full_git_url" != $(git remote get-url origin) ]]; then
     git remote set-url origin "$full_git_url"
 fi
 
-git config advice.skippedCherryPicks false
-
 # Check if branch exists on remote (newly created repos will not yet have a remote) and pull any new changes
 if git ls-remote --exit-code --heads origin $branch_name >/dev/null 2>&1; then
     git pull origin "$branch_name"

--- a/script.sh
+++ b/script.sh
@@ -115,7 +115,8 @@ done < <(grep -v '^#' "$parent_path/.env" | grep 'path_' | sed 's/^.*=//')
 
 cp "$parent_path"/.gitignore "$backup_path/.gitignore"
 
-# Loop through exclude array and add each element to the end of .gitignore so that git does not upload them to remote
+# utilize gits native exclusion file .gitignore to add files that should not be uploaded to remote.
+# Loop through exclude array and add each element to the end of .gitignore
 for i in ${exclude[@]}; do
     # add new line to end of .gitignore if there is not one
     [[ $(tail -c1 "$backup_path/.gitignore" | wc -l) -eq 0 ]] && echo "" >>"$backup_path/.gitignore"
@@ -134,7 +135,6 @@ cd "$backup_path"
 if ! [ -f "README.md" ]; then
     echo -e "# klipper-backup 💾 \nKlipper backup script for manual or automated GitHub backups \n\nThis backup is provided by [klipper-backup](https://github.com/Staubgeborener/klipper-backup)." >"$backup_path/README.md"
 fi
-
 # Untrack all files so that any new excluded files are correctly ignored and deleted from remote
 git rm -r --cached . >/dev/null 2>&1
 git add .

--- a/script.sh
+++ b/script.sh
@@ -32,10 +32,15 @@ if [ ! -d ".git" ]; then
     echo "[init]
     defaultBranch = "$branch_name"" >>.git/config #Add desired branch name to config before init
     git init
-# Check if the current checked out branch matches the branch name given in .env if not update to new branch
+# Check if the current checked out branch matches the branch name given in .env if not branch listed in .env
 elif [[ $(git symbolic-ref --short -q HEAD) != "$branch_name" ]]; then
-    echo "New branch in .env detected, rename $(git symbolic-ref --short -q HEAD) to $branch_name branch"
-    git branch -m "$branch_name"
+    echo "Branch: $branch_name in .env does not match the currently checked out branch: $(git symbolic-ref --short -q HEAD) switching to branch: $branch_name"
+    # Create branch if it does not exist
+    if git show-ref --quiet refs/heads/"$branch"; then
+        git checkout "$branch_name"
+    else
+        git checkout -b "$branch_name"
+    fi
 fi
 
 # Check if username is defined in .env

--- a/script.sh
+++ b/script.sh
@@ -17,8 +17,7 @@ full_git_url="https://"$github_token"@"$git_host"/"$github_username"/"$github_re
 exclude=${exclude:-"*.swp" "*.tmp" "printer-[0-9]*_[0-9]*.cfg" "*.bak" "*.bkp" "*.csv" "*.zip"}
 
 # Check for updates
-[ $(git -C "$parent_path" rev-parse HEAD) = $(git -C "$parent_path" ls-remote $(git -C "$parent_path" rev-parse --abbrev-ref @{u} |
-    sed 's/\// /g') | cut -f1) ] && echo -e "Klipper-backup is up to date\n" || echo -e "NEW klipper-backup version available!\n"
+[ $(git -C "$parent_path" rev-parse HEAD) = $(git -C "$parent_path" ls-remote $(git -C "$parent_path" rev-parse --abbrev-ref @{u} | sed 's/\// /g') | cut -f1) ] && echo -e "Klipper-backup is up to date\n" || echo -e "NEW klipper-backup version available!\n"
 
 # Check if backup folder exists, create one if it does not
 if [ ! -d "$backup_path" ]; then

--- a/script.sh
+++ b/script.sh
@@ -14,6 +14,7 @@ backup_path="$HOME/$backup_folder"
 empty_commit=${empty_commit:-"yes"}
 git_host=${git_host:-"github.com"}
 full_git_url="https://"$github_token"@"$git_host"/"$github_username"/"$github_repository".git"
+exclude=${exclude:-"*.swp" "*.tmp" "printer-[0-9]*_[0-9]*.cfg" "*.bak" "*.bkp" "*.csv" "*.zip"}
 
 # Check for updates
 [ $(git -C "$parent_path" rev-parse HEAD) = $(git -C "$parent_path" ls-remote $(git -C "$parent_path" rev-parse --abbrev-ref @{u} |
@@ -111,6 +112,13 @@ while IFS= read -r path; do
 done < <(grep -v '^#' "$parent_path/.env" | grep 'path_' | sed 's/^.*=//')
 
 cp "$parent_path"/.gitignore "$backup_path/.gitignore"
+
+# Loop through exclude array and add each element to the end of .gitignore so that git does not upload them to remote
+for i in ${exclude[@]}; do
+    # add new line to end of .gitignore if there is not one
+    [[ $(tail -c1 "$backup_path/.gitignore" | wc -l) -eq 0 ]] && echo "" >>"$backup_path/.gitignore"
+    echo $i >>"$backup_path/.gitignore"
+done
 
 # Create and add Readme to backup folder
 echo -e "# klipper-backup 💾 \nKlipper backup script for manual or automated GitHub backups \n\nThis backup is provided by [klipper-backup](https://github.com/Staubgeborener/klipper-backup)." >"$backup_path/README.md"


### PR DESCRIPTION
- Allow Multiple branches per repo instead of renaming the branch when it doesn't match in .env. 
  Allows for things like multiple printer backups under one repo with different branch names per printer or possibly other uses (Future TODO/IDEA: Configure backup paths per branch)
- Exclude list utilizes gits' native .gitignore file to create a list of files/folders to ignore and not upload to the remote repository. would like solve #51 
- README.md can be modified and will persist across backups as it's now only created when it does not initially exist.
- ran shell format/lint to make all indentation and code uniform