### PR TITLE
Update klipper-backup-on-boot.service

### DIFF
--- a/install-files/klipper-backup-on-boot.service
+++ b/install-files/klipper-backup-on-boot.service
@@ -6,7 +6,7 @@ Wants=
 [Service]
 User=
 Type=oneshot
-ExecStart=/usr/bin/env bash  -c "/usr/bin/env bash $HOME/klipper-backup/script.sh \"New Backup on boot - $(date +\"%%x - %%X\")\""
+ExecStart=/usr/bin/env bash  -c "/usr/bin/env bash $HOME/klipper-backup/script.sh -c \"New Backup on boot - $(date +\"%%x - %%X\")\""
 
 [Install]
 WantedBy=default.target

--- a/install.sh
+++ b/install.sh
@@ -437,7 +437,7 @@ install_cron() {
             loading_pid=$!
             (
                 crontab -l 2>/dev/null
-                echo "0 */4 * * * $HOME/klipper-backup/script.sh \"Cron backup - \$(date +\"%x - %X\")\""
+                echo "0 */4 * * * $HOME/klipper-backup/script.sh -c \"Cron backup - \$(date +\"%x - %X\")\""
             ) | crontab -
             sleep .5
             kill $loading_pid

--- a/utils/filewatch.sh
+++ b/utils/filewatch.sh
@@ -25,5 +25,5 @@ while read -r path event file; do
         file=$(basename "$path")
     fi
     echo "Event Type: $event, Watched Path: $path, File Name: $file"
-    file="$file" /usr/bin/env bash -c "/usr/bin/env bash  $HOME/klipper-backup/script.sh \"\$file modified - \$(date +'%x - %X')\"" > /dev/null 2>&1
+    file="$file" /usr/bin/env bash -c "/usr/bin/env bash  $HOME/klipper-backup/script.sh -c \"\$file modified - \$(date +'%x - %X')\"" > /dev/null 2>&1
 done


### PR DESCRIPTION
Add `-c `parameter for the commit message in specific files (like filewatch, cronjob, install script, etc) to fix a bug (reference: [#115 ](https://github.com/Staubgeborener/klipper-backup/issues/115) and [#114 ](https://github.com/Staubgeborener/klipper-backup/issues/114)).