### PR TITLE
Fix crontab formatting

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -437,7 +437,7 @@ install_cron() {
             loading_pid=$!
             (
                 crontab -l 2>/dev/null
-                echo "0 */4 * * * $HOME/klipper-backup/script.sh -c \"Cron backup - \$(date +\"%x - %X\")\""
+                echo "0 */4 * * * $HOME/klipper-backup/script.sh -c \"Cron backup - \$(date +'\\%x - \\%X')\""
             ) | crontab -
             sleep .5
             kill $loading_pid


### PR DESCRIPTION
The previous crontab syntax had a few issues:
- The quotes end up being mixed, change quotes to single quotes to make
  managing easier
- Percent has to be escaped, unescaped % is treated as newline and rest
  of the content is passed in stdin to the command
