### PR TITLE
Feature exlude gitmodules from removal

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -193,8 +193,6 @@ if [[ "$full_git_url" != $(git remote get-url origin) ]]; then
     git remote set-url origin "$full_git_url"
 fi
 
-
-
 # Check if branch exists on remote (newly created repos will not yet have a remote) and pull any new changes
 if git ls-remote --exit-code --heads origin $branch_name >/dev/null 2>&1; then
     git pull origin "$branch_name"


### PR DESCRIPTION
This pull request makes sub git folder linkeable to github. Handling of `.gitmodules` files, exclusion of certain directories during backup, and improved debug output initialization. 
The changes help ensure that unnecessary .git and .github folder are excluded from backups.

**Backup directory cleanup improvements:**
* Modified `find` commands to prevent deletion of `.gitmodules` in addition to `.git` and `README.md` after pulling and pushing backups, ensuring that submodule information is retained.

**Backup file selection enhancements:**
* Updated `rsync` command to exclude `.git` and `.github` directories from backups, reducing unnecessary data and potential security risks.

**Debug Option:**
* Changed initialization of `debug_output` to use a default value if not already set, improving script reliability when the variable is unset.