### PR TITLE
feat: Implement AI-powered commit message generation

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -264,6 +264,17 @@ fi
 # Untrack all files so that any new excluded files are correctly ignored and deleted from remote
 git rm -r --cached . >/dev/null 2>&1
 git add .
+
+if [[ -n "$ai_describe_commit_command" ]]; then
+    described_commit=$(${ai_describe_commit_command})
+    ret=$?
+    if [[ $ret -ne 0 ]]; then
+        printf "\r\033[K${R}Error: describe-commit command failed with exit code %d. Falling back to default commit message.${NC}\n" $ret
+    elif [[ -n "$described_commit" ]]; then
+        commit_message="$described_commit"
+    fi
+fi
+
 git commit -m "$commit_message"
 # Check if HEAD still matches remote (Means there are no updates to push) and create a empty commit just informing that there are no new updates to push
 if $allow_empty_commits && [[ $(git rev-parse HEAD) == $(git ls-remote $(git rev-parse --abbrev-ref @{u} 2>/dev/null | sed 's/\// /g') | cut -f1) ]]; then


### PR DESCRIPTION
Adds support for using AI to generate commit messages via the `describe-commit` tool, enhancing commit clarity and detail. This feature is configurable via `.env` variables.

see: [describe-commit](https://github.com/tarampampam/describe-commit)

This feature would be completely optional, and disabled by default.

Here are the last few commits that were generated while testing this functionality. I tested using gemini with the default gemini model (gemini-2.0-flash).

<img width="1037" height="617" alt="Screenshot 2026-01-07 at 10 19 03 PM" src="https://github.com/user-attachments/assets/deba5dd7-03a9-48da-848a-736c8d9f0d65" />
