### PR TITLE
Add `ShakeTune_results` to default exclude list

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,4 +34,5 @@ exclude=( \
 "*.bkp" \
 "*.csv" \
 "*.zip" \
+"ShakeTune_results" \
 )


### PR DESCRIPTION
The [Shake&Tune](https://github.com/Frix-x/klippain-shaketune) Klipper plugin generates `.png` graphs and `.stdata` files in the `ShakeTune_results` folder under printer config. 
These are temporary diagnostic files that get regenerated on every run and don't really belong in a backup repo — they just add noise to commits and bloat the repository.

This adds `ShakeTune_results` directory to the default exclude list in .env.example so these files are ignored out of the box.